### PR TITLE
Use SpecificationBuilderInterface instead of SpecificationBuilder in Factory

### DIFF
--- a/src/Spryker/Zed/Discount/Business/DiscountBusinessFactory.php
+++ b/src/Spryker/Zed/Discount/Business/DiscountBusinessFactory.php
@@ -328,7 +328,7 @@ class DiscountBusinessFactory extends AbstractBusinessFactory
     }
 
     /**
-     * @return \Spryker\Zed\Discount\Business\QueryString\SpecificationBuilder
+     * @return \Spryker\Zed\Discount\Business\QueryString\SpecificationBuilderInterface
      */
     protected function createDecisionRuleBuilder()
     {


### PR DESCRIPTION
## PR Description

This allows us to extend that part in the project code without inheriting from the base-class but using the same interface, just as it's done in `\Spryker\Zed\Discount\Business\DiscountBusinessFactory::createCollectorBuilder`. We usually prefer decorators that implement the same interface over a child class in such cases, but this will not work here, since a SA error will be reported.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
