### PR TITLE
SUPESC-667 Backport for allowing individual comparators to define if comparison with an empty value is allowed.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "php": ">=7.1",
     "spryker/cart-extension": "^1.0.0 || ^2.0.0",
     "spryker/currency": "^3.1.0",
-    "spryker/discount-extension": "^1.0.0",
+    "spryker/discount-extension": "^1.2.0",
     "spryker/gui": "^3.7.0",
     "spryker/kernel": "^3.11.0",
     "spryker/log": "^3.0.0",

--- a/src/Spryker/Zed/Discount/Business/DiscountBusinessFactory.php
+++ b/src/Spryker/Zed/Discount/Business/DiscountBusinessFactory.php
@@ -142,7 +142,7 @@ class DiscountBusinessFactory extends AbstractBusinessFactory
     }
 
     /**
-     * @return \Spryker\Zed\Discount\Dependency\Plugin\DecisionRulePluginInterface[]
+     * @return \Spryker\Zed\DiscountExtension\Dependency\Plugin\DecisionRulePluginInterface[]
      */
     public function getDecisionRulePlugins()
     {
@@ -177,7 +177,7 @@ class DiscountBusinessFactory extends AbstractBusinessFactory
     }
 
     /**
-     * @return \Spryker\Zed\Discount\Dependency\Plugin\CollectorPluginInterface[]
+     * @return \Spryker\Zed\DiscountExtension\Dependency\Plugin\DiscountableItemCollectorPluginInterface[]
      */
     public function getCollectorPlugins()
     {

--- a/src/Spryker/Zed/Discount/Business/QueryString/Comparator/AbstractComparator.php
+++ b/src/Spryker/Zed/Discount/Business/QueryString/Comparator/AbstractComparator.php
@@ -34,7 +34,7 @@ abstract class AbstractComparator implements ComparatorInterface
     {
         if (!is_scalar($withValue)) {
             throw new ComparatorException(
-                sprintf('Only scalar value can be used together with "%s" comparator.', $this->getExpression()),
+                sprintf('Only scalar value can be used together with "%s" comparator.', $this->getExpression())
             );
         }
 

--- a/src/Spryker/Zed/Discount/Business/QueryString/Comparator/AbstractComparator.php
+++ b/src/Spryker/Zed/Discount/Business/QueryString/Comparator/AbstractComparator.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Zed\Discount\Business\QueryString\Comparator;
+
+use Generated\Shared\Transfer\ClauseTransfer;
+use Spryker\Zed\Discount\Business\Exception\ComparatorException;
+use Spryker\Zed\Discount\Business\QueryString\ComparatorOperators;
+
+abstract class AbstractComparator implements ComparatorInterface
+{
+    /**
+     * @var string
+     */
+    protected const EXPRESSION = '';
+
+    /**
+     * @var bool
+     */
+    protected const ALLOW_EMPTY_VALUE = false;
+
+    /**
+     * @param mixed $withValue
+     *
+     * @throws \Spryker\Zed\Discount\Business\Exception\ComparatorException
+     *
+     * @return bool
+     */
+    public function isValidValue($withValue): bool
+    {
+        if (!is_scalar($withValue)) {
+            throw new ComparatorException(
+                sprintf('Only scalar value can be used together with "%s" comparator.', static::EXPRESSION),
+            );
+        }
+
+        return static::ALLOW_EMPTY_VALUE || !$this->isEmptyValue($withValue);
+    }
+
+    /**
+     * @return string
+     */
+    public function getExpression(): string
+    {
+        return static::EXPRESSION;
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\ClauseTransfer $clauseTransfer
+     *
+     * @return bool
+     */
+    public function accept(ClauseTransfer $clauseTransfer): bool
+    {
+        return strcasecmp($clauseTransfer->getOperatorOrFail(), $this->getExpression()) === 0;
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return bool
+     */
+    protected function isEmptyValue($value): bool
+    {
+        return (string)$value === '';
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return list<string>
+     */
+    protected function getExplodedListValue(string $value): array
+    {
+        $explodedValues = explode(ComparatorOperators::LIST_DELIMITER, $value);
+
+        return array_map(function (string $explodedValue) {
+            return strtolower(trim($explodedValue));
+        }, $explodedValues);
+    }
+}

--- a/src/Spryker/Zed/Discount/Business/QueryString/Comparator/AbstractComparator.php
+++ b/src/Spryker/Zed/Discount/Business/QueryString/Comparator/AbstractComparator.php
@@ -34,7 +34,7 @@ abstract class AbstractComparator implements ComparatorInterface
     {
         if (!is_scalar($withValue)) {
             throw new ComparatorException(
-                sprintf('Only scalar value can be used together with "%s" comparator.', static::EXPRESSION),
+                sprintf('Only scalar value can be used together with "%s" comparator.', $this->getExpression()),
             );
         }
 

--- a/src/Spryker/Zed/Discount/Business/QueryString/Comparator/ComparatorInterface.php
+++ b/src/Spryker/Zed/Discount/Business/QueryString/Comparator/ComparatorInterface.php
@@ -13,35 +13,35 @@ interface ComparatorInterface
 {
     /**
      * @param \Generated\Shared\Transfer\ClauseTransfer $clauseTransfer
-     * @param string $withValue
+     * @param mixed $withValue
      *
      * @return bool
      */
-    public function compare(ClauseTransfer $clauseTransfer, $withValue);
+    public function compare(ClauseTransfer $clauseTransfer, $withValue): bool;
 
     /**
-     * @param string $withValue
+     * @param mixed $withValue
      *
      * @throws \Spryker\Zed\Discount\Business\Exception\ComparatorException
      *
      * @return bool
      */
-    public function isValidValue($withValue);
+    public function isValidValue($withValue): bool;
 
     /**
      * @param \Generated\Shared\Transfer\ClauseTransfer $clauseTransfer
      *
      * @return bool
      */
-    public function accept(ClauseTransfer $clauseTransfer);
+    public function accept(ClauseTransfer $clauseTransfer): bool;
 
     /**
      * @return string
      */
-    public function getExpression();
+    public function getExpression(): string;
 
     /**
-     * @return string[]
+     * @return list<string>
      */
-    public function getAcceptedTypes();
+    public function getAcceptedTypes(): array;
 }

--- a/src/Spryker/Zed/Discount/Business/QueryString/Comparator/Contains.php
+++ b/src/Spryker/Zed/Discount/Business/QueryString/Comparator/Contains.php
@@ -8,66 +8,38 @@
 namespace Spryker\Zed\Discount\Business\QueryString\Comparator;
 
 use Generated\Shared\Transfer\ClauseTransfer;
-use Spryker\Zed\Discount\Business\Exception\ComparatorException;
 use Spryker\Zed\Discount\Business\QueryString\ComparatorOperators;
 
-class Contains implements ComparatorInterface
+class Contains extends AbstractComparator implements ComparatorInterface
 {
     /**
+     * @var string
+     */
+    protected const EXPRESSION = 'contains';
+
+    /**
      * @param \Generated\Shared\Transfer\ClauseTransfer $clauseTransfer
-     * @param string $withValue
+     * @param mixed $withValue
      *
      * @return bool
      */
-    public function compare(ClauseTransfer $clauseTransfer, $withValue)
+    public function compare(ClauseTransfer $clauseTransfer, $withValue): bool
     {
-        $this->isValidValue($withValue);
+        if (!$this->isValidValue($withValue)) {
+            return false;
+        }
 
         return (stripos(trim($withValue), $clauseTransfer->getValue()) !== false);
     }
 
     /**
-     * @param \Generated\Shared\Transfer\ClauseTransfer $clauseTransfer
-     *
-     * @return bool
+     * @return list<string>
      */
-    public function accept(ClauseTransfer $clauseTransfer)
-    {
-        return (strcasecmp($clauseTransfer->getOperator(), $this->getExpression()) === 0);
-    }
-
-    /**
-     * @return string
-     */
-    public function getExpression()
-    {
-        return 'contains';
-    }
-
-    /**
-     * @return string[]
-     */
-    public function getAcceptedTypes()
+    public function getAcceptedTypes(): array
     {
         return [
             ComparatorOperators::TYPE_STRING,
             ComparatorOperators::TYPE_NUMBER,
         ];
-    }
-
-    /**
-     * @param string $withValue
-     *
-     * @throws \Spryker\Zed\Discount\Business\Exception\ComparatorException
-     *
-     * @return bool
-     */
-    public function isValidValue($withValue)
-    {
-        if (!is_scalar($withValue)) {
-            throw new ComparatorException('Only scalar value can be used together with "contains" comparator.');
-        }
-
-        return true;
     }
 }

--- a/src/Spryker/Zed/Discount/Business/QueryString/Comparator/DoesNotContain.php
+++ b/src/Spryker/Zed/Discount/Business/QueryString/Comparator/DoesNotContain.php
@@ -8,66 +8,38 @@
 namespace Spryker\Zed\Discount\Business\QueryString\Comparator;
 
 use Generated\Shared\Transfer\ClauseTransfer;
-use Spryker\Zed\Discount\Business\Exception\ComparatorException;
 use Spryker\Zed\Discount\Business\QueryString\ComparatorOperators;
 
-class DoesNotContain implements ComparatorInterface
+class DoesNotContain extends AbstractComparator implements ComparatorInterface
 {
     /**
+     * @var string
+     */
+    protected const EXPRESSION = 'does not contain';
+
+    /**
      * @param \Generated\Shared\Transfer\ClauseTransfer $clauseTransfer
-     * @param string $withValue
+     * @param mixed $withValue
      *
      * @return bool
      */
-    public function compare(ClauseTransfer $clauseTransfer, $withValue)
+    public function compare(ClauseTransfer $clauseTransfer, $withValue): bool
     {
-        $this->isValidValue($withValue);
+        if (!$this->isValidValue($withValue)) {
+            return false;
+        }
 
         return (stripos(trim($withValue), $clauseTransfer->getValue()) === false);
     }
 
     /**
-     * @param \Generated\Shared\Transfer\ClauseTransfer $clauseTransfer
-     *
-     * @return bool
+     * @return list<string>
      */
-    public function accept(ClauseTransfer $clauseTransfer)
-    {
-        return (strcasecmp($clauseTransfer->getOperator(), $this->getExpression()) === 0);
-    }
-
-    /**
-     * @return string
-     */
-    public function getExpression()
-    {
-        return 'does not contain';
-    }
-
-    /**
-     * @return string[]
-     */
-    public function getAcceptedTypes()
+    public function getAcceptedTypes(): array
     {
         return [
             ComparatorOperators::TYPE_STRING,
             ComparatorOperators::TYPE_NUMBER,
         ];
-    }
-
-    /**
-     * @param string $withValue
-     *
-     * @throws \Spryker\Zed\Discount\Business\Exception\ComparatorException
-     *
-     * @return bool
-     */
-    public function isValidValue($withValue)
-    {
-        if (!is_scalar($withValue)) {
-            throw new ComparatorException('Only scalar value can be used together with "does not contain" comparator.');
-        }
-
-        return true;
     }
 }

--- a/src/Spryker/Zed/Discount/Business/QueryString/Comparator/Equal.php
+++ b/src/Spryker/Zed/Discount/Business/QueryString/Comparator/Equal.php
@@ -8,66 +8,38 @@
 namespace Spryker\Zed\Discount\Business\QueryString\Comparator;
 
 use Generated\Shared\Transfer\ClauseTransfer;
-use Spryker\Zed\Discount\Business\Exception\ComparatorException;
 use Spryker\Zed\Discount\Business\QueryString\ComparatorOperators;
 
-class Equal implements ComparatorInterface
+class Equal extends AbstractComparator implements ComparatorInterface
 {
     /**
+     * @var string
+     */
+    protected const EXPRESSION = '=';
+
+    /**
      * @param \Generated\Shared\Transfer\ClauseTransfer $clauseTransfer
-     * @param string $withValue
+     * @param mixed $withValue
      *
      * @return bool
      */
-    public function compare(ClauseTransfer $clauseTransfer, $withValue)
+    public function compare(ClauseTransfer $clauseTransfer, $withValue): bool
     {
-        $this->isValidValue($withValue);
+        if (!$this->isValidValue($withValue)) {
+            return false;
+        }
 
         return strcasecmp($clauseTransfer->getValue(), $withValue) === 0;
     }
 
     /**
-     * @param \Generated\Shared\Transfer\ClauseTransfer $clauseTransfer
-     *
-     * @return bool
+     * @return list<string>
      */
-    public function accept(ClauseTransfer $clauseTransfer)
-    {
-        return (strcasecmp($clauseTransfer->getOperator(), $this->getExpression()) === 0);
-    }
-
-    /**
-     * @return string
-     */
-    public function getExpression()
-    {
-        return '=';
-    }
-
-    /**
-     * @return string[]
-     */
-    public function getAcceptedTypes()
+    public function getAcceptedTypes(): array
     {
         return [
             ComparatorOperators::TYPE_NUMBER,
             ComparatorOperators::TYPE_STRING,
         ];
-    }
-
-    /**
-     * @param string $withValue
-     *
-     * @throws \Spryker\Zed\Discount\Business\Exception\ComparatorException
-     *
-     * @return bool
-     */
-    public function isValidValue($withValue)
-    {
-        if (!is_scalar($withValue)) {
-            throw new ComparatorException('Only scalar value can be used together with "=" comparator.');
-        }
-
-        return true;
     }
 }

--- a/src/Spryker/Zed/Discount/Business/QueryString/Comparator/Greater.php
+++ b/src/Spryker/Zed/Discount/Business/QueryString/Comparator/Greater.php
@@ -11,43 +11,32 @@ use Generated\Shared\Transfer\ClauseTransfer;
 use Spryker\Zed\Discount\Business\Exception\ComparatorException;
 use Spryker\Zed\Discount\Business\QueryString\ComparatorOperators;
 
-class Greater implements ComparatorInterface
+class Greater extends AbstractComparator implements ComparatorInterface
 {
     /**
+     * @var string
+     */
+    protected const EXPRESSION = '>';
+
+    /**
      * @param \Generated\Shared\Transfer\ClauseTransfer $clauseTransfer
-     * @param string $withValue
+     * @param mixed $withValue
      *
      * @return bool
      */
-    public function compare(ClauseTransfer $clauseTransfer, $withValue)
+    public function compare(ClauseTransfer $clauseTransfer, $withValue): bool
     {
-        $this->isValidValue($withValue);
+        if (!$this->isValidValue($withValue)) {
+            return false;
+        }
 
         return $withValue > $clauseTransfer->getValue();
     }
 
     /**
-     * @param \Generated\Shared\Transfer\ClauseTransfer $clauseTransfer
-     *
-     * @return bool
+     * @return list<string>
      */
-    public function accept(ClauseTransfer $clauseTransfer)
-    {
-        return (strcasecmp($clauseTransfer->getOperator(), $this->getExpression()) === 0);
-    }
-
-    /**
-     * @return string
-     */
-    public function getExpression()
-    {
-        return '>';
-    }
-
-    /**
-     * @return string[]
-     */
-    public function getAcceptedTypes()
+    public function getAcceptedTypes(): array
     {
         return [
             ComparatorOperators::TYPE_NUMBER,
@@ -55,14 +44,18 @@ class Greater implements ComparatorInterface
     }
 
     /**
-     * @param string $withValue
+     * @param mixed $withValue
      *
      * @throws \Spryker\Zed\Discount\Business\Exception\ComparatorException
      *
      * @return bool
      */
-    public function isValidValue($withValue)
+    public function isValidValue($withValue): bool
     {
+        if (!parent::isValidValue($withValue)) {
+            return false;
+        }
+
         if (preg_match(ComparatorOperators::NUMBER_REGEXP, $withValue) === 0) {
             throw new ComparatorException('Only numeric value can be used together with ">" comparator.');
         }

--- a/src/Spryker/Zed/Discount/Business/QueryString/Comparator/GreaterEqual.php
+++ b/src/Spryker/Zed/Discount/Business/QueryString/Comparator/GreaterEqual.php
@@ -11,43 +11,32 @@ use Generated\Shared\Transfer\ClauseTransfer;
 use Spryker\Zed\Discount\Business\Exception\ComparatorException;
 use Spryker\Zed\Discount\Business\QueryString\ComparatorOperators;
 
-class GreaterEqual implements ComparatorInterface
+class GreaterEqual extends AbstractComparator implements ComparatorInterface
 {
     /**
+     * @var string
+     */
+    protected const EXPRESSION = '>=';
+
+    /**
      * @param \Generated\Shared\Transfer\ClauseTransfer $clauseTransfer
-     * @param string $withValue
+     * @param mixed $withValue
      *
      * @return bool
      */
-    public function compare(ClauseTransfer $clauseTransfer, $withValue)
+    public function compare(ClauseTransfer $clauseTransfer, $withValue): bool
     {
-        $this->isValidValue($withValue);
+        if (!$this->isValidValue($withValue)) {
+            return false;
+        }
 
         return $withValue >= $clauseTransfer->getValue();
     }
 
     /**
-     * @param \Generated\Shared\Transfer\ClauseTransfer $clauseTransfer
-     *
-     * @return bool
+     * @return list<string>
      */
-    public function accept(ClauseTransfer $clauseTransfer)
-    {
-        return (strcasecmp($clauseTransfer->getOperator(), $this->getExpression()) === 0);
-    }
-
-    /**
-     * @return string
-     */
-    public function getExpression()
-    {
-        return '>=';
-    }
-
-    /**
-     * @return string[]
-     */
-    public function getAcceptedTypes()
+    public function getAcceptedTypes(): array
     {
         return [
             ComparatorOperators::TYPE_NUMBER,
@@ -55,14 +44,18 @@ class GreaterEqual implements ComparatorInterface
     }
 
     /**
-     * @param string $withValue
+     * @param mixed $withValue
      *
      * @throws \Spryker\Zed\Discount\Business\Exception\ComparatorException
      *
      * @return bool
      */
-    public function isValidValue($withValue)
+    public function isValidValue($withValue): bool
     {
+        if (!parent::isValidValue($withValue)) {
+            return false;
+        }
+
         if (preg_match(ComparatorOperators::NUMBER_REGEXP, $withValue) === 0) {
             throw new ComparatorException('Only numeric value can be used together with ">=" comparator.');
         }

--- a/src/Spryker/Zed/Discount/Business/QueryString/Comparator/IsIn.php
+++ b/src/Spryker/Zed/Discount/Business/QueryString/Comparator/IsIn.php
@@ -8,71 +8,40 @@
 namespace Spryker\Zed\Discount\Business\QueryString\Comparator;
 
 use Generated\Shared\Transfer\ClauseTransfer;
-use Spryker\Zed\Discount\Business\Exception\ComparatorException;
 use Spryker\Zed\Discount\Business\QueryString\ComparatorOperators;
 
-class IsIn implements ComparatorInterface
+class IsIn extends AbstractComparator implements ComparatorInterface
 {
-    public const EXPRESSION = 'is in';
+    /**
+     * @var string
+     */
+    protected const EXPRESSION = 'is in';
 
     /**
      * @param \Generated\Shared\Transfer\ClauseTransfer $clauseTransfer
-     * @param string $withValue
+     * @param mixed $withValue
      *
      * @return bool
      */
-    public function compare(ClauseTransfer $clauseTransfer, $withValue)
+    public function compare(ClauseTransfer $clauseTransfer, $withValue): bool
     {
-        $this->isValidValue($withValue);
+        if (!$this->isValidValue($withValue)) {
+            return false;
+        }
 
-        $values = explode(ComparatorOperators::LIST_DELIMITER, $clauseTransfer->getValue());
+        $searchValues = $this->getExplodedListValue((string)$withValue);
+        $clauseValues = $this->getExplodedListValue((string)$clauseTransfer->getValue());
 
-        $values = array_map('trim', $values);
-
-        return in_array(strtolower($withValue), $values);
+        return array_intersect($searchValues, $clauseValues) !== [];
     }
 
     /**
-     * @param \Generated\Shared\Transfer\ClauseTransfer $clauseTransfer
-     *
-     * @return bool
+     * @return list<string>
      */
-    public function accept(ClauseTransfer $clauseTransfer)
-    {
-        return (strcasecmp($clauseTransfer->getOperator(), $this->getExpression()) === 0);
-    }
-
-    /**
-     * @return string
-     */
-    public function getExpression()
-    {
-        return static::EXPRESSION;
-    }
-
-    /**
-     * @return string[]
-     */
-    public function getAcceptedTypes()
+    public function getAcceptedTypes(): array
     {
         return [
             ComparatorOperators::TYPE_LIST,
         ];
-    }
-
-    /**
-     * @param string $withValue
-     *
-     * @throws \Spryker\Zed\Discount\Business\Exception\ComparatorException
-     *
-     * @return bool
-     */
-    public function isValidValue($withValue)
-    {
-        if (!is_scalar($withValue)) {
-            throw new ComparatorException('Only scalar value can be used together with "is in" comparator.');
-        }
-
-        return true;
     }
 }

--- a/src/Spryker/Zed/Discount/Business/QueryString/Comparator/IsNotIn.php
+++ b/src/Spryker/Zed/Discount/Business/QueryString/Comparator/IsNotIn.php
@@ -8,71 +8,45 @@
 namespace Spryker\Zed\Discount\Business\QueryString\Comparator;
 
 use Generated\Shared\Transfer\ClauseTransfer;
-use Spryker\Zed\Discount\Business\Exception\ComparatorException;
 use Spryker\Zed\Discount\Business\QueryString\ComparatorOperators;
 
-class IsNotIn implements ComparatorInterface
+class IsNotIn extends AbstractComparator implements ComparatorInterface
 {
-    public const EXPRESSION = 'is not in';
+    /**
+     * @var string
+     */
+    protected const EXPRESSION = 'is not in';
+
+    /**
+     * @var bool
+     */
+    protected const ALLOW_EMPTY_VALUE = true;
 
     /**
      * @param \Generated\Shared\Transfer\ClauseTransfer $clauseTransfer
-     * @param string $withValue
+     * @param mixed $withValue
      *
      * @return bool
      */
-    public function compare(ClauseTransfer $clauseTransfer, $withValue)
+    public function compare(ClauseTransfer $clauseTransfer, $withValue): bool
     {
-        $this->isValidValue($withValue);
+        if (!$this->isValidValue($withValue)) {
+            return false;
+        }
 
-        $values = explode(ComparatorOperators::LIST_DELIMITER, $clauseTransfer->getValue());
+        $searchValues = $this->getExplodedListValue((string)$withValue);
+        $clauseValues = $this->getExplodedListValue((string)$clauseTransfer->getValue());
 
-        $values = array_map('trim', $values);
-
-        return !in_array(strtolower($withValue), $values);
+        return array_intersect($searchValues, $clauseValues) === [];
     }
 
     /**
-     * @param \Generated\Shared\Transfer\ClauseTransfer $clauseTransfer
-     *
-     * @return bool
+     * @return list<string>
      */
-    public function accept(ClauseTransfer $clauseTransfer)
-    {
-        return (strcasecmp($clauseTransfer->getOperator(), $this->getExpression()) === 0);
-    }
-
-    /**
-     * @return string
-     */
-    public function getExpression()
-    {
-        return static::EXPRESSION;
-    }
-
-    /**
-     * @return string[]
-     */
-    public function getAcceptedTypes()
+    public function getAcceptedTypes(): array
     {
         return [
             ComparatorOperators::TYPE_LIST,
         ];
-    }
-
-    /**
-     * @param string $withValue
-     *
-     * @throws \Spryker\Zed\Discount\Business\Exception\ComparatorException
-     *
-     * @return bool
-     */
-    public function isValidValue($withValue)
-    {
-        if (!is_scalar($withValue)) {
-            throw new ComparatorException('Only scalar value can be used together with "is not in" comparator.');
-        }
-
-        return true;
     }
 }

--- a/src/Spryker/Zed/Discount/Business/QueryString/Comparator/Less.php
+++ b/src/Spryker/Zed/Discount/Business/QueryString/Comparator/Less.php
@@ -11,43 +11,32 @@ use Generated\Shared\Transfer\ClauseTransfer;
 use Spryker\Zed\Discount\Business\Exception\ComparatorException;
 use Spryker\Zed\Discount\Business\QueryString\ComparatorOperators;
 
-class Less implements ComparatorInterface
+class Less extends AbstractComparator implements ComparatorInterface
 {
     /**
+     * @var string
+     */
+    protected const EXPRESSION = '<';
+
+    /**
      * @param \Generated\Shared\Transfer\ClauseTransfer $clauseTransfer
-     * @param string $withValue
+     * @param mixed $withValue
      *
      * @return bool
      */
-    public function compare(ClauseTransfer $clauseTransfer, $withValue)
+    public function compare(ClauseTransfer $clauseTransfer, $withValue): bool
     {
-        $this->isValidValue($withValue);
+        if (!$this->isValidValue($withValue)) {
+            return false;
+        }
 
         return $withValue < $clauseTransfer->getValue();
     }
 
     /**
-     * @param \Generated\Shared\Transfer\ClauseTransfer $clauseTransfer
-     *
-     * @return bool
+     * @return list<string>
      */
-    public function accept(ClauseTransfer $clauseTransfer)
-    {
-        return (strcasecmp($clauseTransfer->getOperator(), $this->getExpression()) === 0);
-    }
-
-    /**
-     * @return string
-     */
-    public function getExpression()
-    {
-        return '<';
-    }
-
-    /**
-     * @return string[]
-     */
-    public function getAcceptedTypes()
+    public function getAcceptedTypes(): array
     {
         return [
             ComparatorOperators::TYPE_NUMBER,
@@ -55,14 +44,18 @@ class Less implements ComparatorInterface
     }
 
     /**
-     * @param string $withValue
+     * @param mixed $withValue
      *
      * @throws \Spryker\Zed\Discount\Business\Exception\ComparatorException
      *
      * @return bool
      */
-    public function isValidValue($withValue)
+    public function isValidValue($withValue): bool
     {
+        if (!parent::isValidValue($withValue)) {
+            return false;
+        }
+
         if (preg_match(ComparatorOperators::NUMBER_REGEXP, $withValue) === 0) {
             throw new ComparatorException('Only numeric value can be used together with "<" comparator.');
         }

--- a/src/Spryker/Zed/Discount/Business/QueryString/Comparator/LessEqual.php
+++ b/src/Spryker/Zed/Discount/Business/QueryString/Comparator/LessEqual.php
@@ -11,43 +11,32 @@ use Generated\Shared\Transfer\ClauseTransfer;
 use Spryker\Zed\Discount\Business\Exception\ComparatorException;
 use Spryker\Zed\Discount\Business\QueryString\ComparatorOperators;
 
-class LessEqual implements ComparatorInterface
+class LessEqual extends AbstractComparator implements ComparatorInterface
 {
     /**
-     * @param \Generated\Shared\Transfer\ClauseTransfer $compareWithValue
-     * @param string $withValue
-     *
-     * @return bool
+     * @var string
      */
-    public function compare(ClauseTransfer $compareWithValue, $withValue)
-    {
-        $this->isValidValue($withValue);
-
-        return $withValue <= $compareWithValue->getValue();
-    }
+    protected const EXPRESSION = '<=';
 
     /**
      * @param \Generated\Shared\Transfer\ClauseTransfer $clauseTransfer
+     * @param mixed $withValue
      *
      * @return bool
      */
-    public function accept(ClauseTransfer $clauseTransfer)
+    public function compare(ClauseTransfer $clauseTransfer, $withValue): bool
     {
-        return (strcasecmp($clauseTransfer->getOperator(), $this->getExpression()) === 0);
+        if (!$this->isValidValue($withValue)) {
+            return false;
+        }
+
+        return $withValue <= $clauseTransfer->getValue();
     }
 
     /**
-     * @return string
+     * @return list<string>
      */
-    public function getExpression()
-    {
-        return '<=';
-    }
-
-    /**
-     * @return string[]
-     */
-    public function getAcceptedTypes()
+    public function getAcceptedTypes(): array
     {
         return [
             ComparatorOperators::TYPE_NUMBER,
@@ -55,14 +44,18 @@ class LessEqual implements ComparatorInterface
     }
 
     /**
-     * @param string $withValue
+     * @param mixed $withValue
      *
      * @throws \Spryker\Zed\Discount\Business\Exception\ComparatorException
      *
      * @return bool
      */
-    public function isValidValue($withValue)
+    public function isValidValue($withValue): bool
     {
+        if (!parent::isValidValue($withValue)) {
+            return false;
+        }
+
         if (preg_match(ComparatorOperators::NUMBER_REGEXP, $withValue) === 0) {
             throw new ComparatorException('Only numeric value can be used together with "<=" comparator.');
         }

--- a/src/Spryker/Zed/Discount/Business/QueryString/Comparator/NotEqual.php
+++ b/src/Spryker/Zed/Discount/Business/QueryString/Comparator/NotEqual.php
@@ -8,66 +8,38 @@
 namespace Spryker\Zed\Discount\Business\QueryString\Comparator;
 
 use Generated\Shared\Transfer\ClauseTransfer;
-use Spryker\Zed\Discount\Business\Exception\ComparatorException;
 use Spryker\Zed\Discount\Business\QueryString\ComparatorOperators;
 
-class NotEqual implements ComparatorInterface
+class NotEqual extends AbstractComparator implements ComparatorInterface
 {
     /**
+     * @var string
+     */
+    protected const EXPRESSION = '!=';
+
+    /**
      * @param \Generated\Shared\Transfer\ClauseTransfer $clauseTransfer
-     * @param string $withValue
+     * @param mixed $withValue
      *
      * @return bool
      */
-    public function compare(ClauseTransfer $clauseTransfer, $withValue)
+    public function compare(ClauseTransfer $clauseTransfer, $withValue): bool
     {
-        $this->isValidValue($withValue);
+        if (!$this->isValidValue($withValue)) {
+            return false;
+        }
 
         return strcasecmp($withValue, $clauseTransfer->getValue()) !== 0;
     }
 
     /**
-     * @param \Generated\Shared\Transfer\ClauseTransfer $clauseTransfer
-     *
-     * @return bool
+     * @return list<string>
      */
-    public function accept(ClauseTransfer $clauseTransfer)
-    {
-        return (strcasecmp($clauseTransfer->getOperator(), $this->getExpression()) === 0);
-    }
-
-    /**
-     * @return string
-     */
-    public function getExpression()
-    {
-        return '!=';
-    }
-
-    /**
-     * @return string[]
-     */
-    public function getAcceptedTypes()
+    public function getAcceptedTypes(): array
     {
         return [
             ComparatorOperators::TYPE_NUMBER,
             ComparatorOperators::TYPE_STRING,
         ];
-    }
-
-    /**
-     * @param string $withValue
-     *
-     * @throws \Spryker\Zed\Discount\Business\Exception\ComparatorException
-     *
-     * @return bool
-     */
-    public function isValidValue($withValue)
-    {
-        if (!is_scalar($withValue)) {
-            throw new ComparatorException('Only scalar value allowed for "!=" operator.');
-        }
-
-        return true;
     }
 }

--- a/src/Spryker/Zed/Discount/Business/QueryString/ComparatorOperators.php
+++ b/src/Spryker/Zed/Discount/Business/QueryString/ComparatorOperators.php
@@ -43,12 +43,8 @@ class ComparatorOperators implements ComparatorOperatorsInterface
      */
     public function compare(ClauseTransfer $clauseTransfer, $withValue)
     {
-        if ((string)$withValue === '') {
-            return false;
-        }
-
         if ($this->isMatchAllValue($clauseTransfer->getValue())) {
-            return true;
+            return (string)$withValue !== '';
         }
 
         foreach ($this->operators as $operator) {

--- a/src/Spryker/Zed/Discount/Business/QueryString/Converter/MoneyValueConverter.php
+++ b/src/Spryker/Zed/Discount/Business/QueryString/Converter/MoneyValueConverter.php
@@ -16,6 +16,20 @@ use Spryker\Zed\Discount\Dependency\Facade\DiscountToMoneyInterface;
 class MoneyValueConverter implements MoneyValueConverterInterface
 {
     /**
+     * @uses \Spryker\Zed\Discount\Business\QueryString\Comparator\IsIn::EXPRESSION
+     *
+     * @var string
+     */
+    protected const EXPRESSION_IS_IN = 'is in';
+
+    /**
+     * @uses \Spryker\Zed\Discount\Business\QueryString\Comparator\IsNotIn::EXPRESSION
+     *
+     * @var string
+     */
+    protected const EXPRESSION_IS_NOT_IN = 'is not in';
+
+    /**
      * @var \Spryker\Zed\Discount\Dependency\Facade\DiscountToMoneyInterface
      */
     protected $moneyFacade;
@@ -35,8 +49,10 @@ class MoneyValueConverter implements MoneyValueConverterInterface
      */
     public function convertDecimalToCent(ClauseTransfer $clauseTransfer)
     {
-        if ($clauseTransfer->getOperator() === IsNotIn::EXPRESSION ||
-            $clauseTransfer->getOperator() === IsIn::EXPRESSION) {
+        if (
+            $clauseTransfer->getOperator() === static::EXPRESSION_IS_NOT_IN ||
+            $clauseTransfer->getOperator() === static::EXPRESSION_IS_IN
+        ) {
             $this->convertListPrice($clauseTransfer);
         } else {
             $this->convertSinglePrice($clauseTransfer);

--- a/src/Spryker/Zed/Discount/Business/QueryString/Specification/CollectorProvider.php
+++ b/src/Spryker/Zed/Discount/Business/QueryString/Specification/CollectorProvider.php
@@ -17,12 +17,12 @@ use Spryker\Zed\Discount\DiscountDependencyProvider;
 class CollectorProvider implements SpecificationProviderInterface
 {
     /**
-     * @var \Spryker\Zed\Discount\Dependency\Plugin\CollectorPluginInterface[]
+     * @var \Spryker\Zed\DiscountExtension\Dependency\Plugin\DiscountableItemCollectorPluginInterface[]
      */
     protected $collectorPlugins = [];
 
     /**
-     * @param \Spryker\Zed\Discount\Dependency\Plugin\CollectorPluginInterface[] $collectorPlugins
+     * @param \Spryker\Zed\DiscountExtension\Dependency\Plugin\DiscountableItemCollectorPluginInterface[] $collectorPlugins
      */
     public function __construct(array $collectorPlugins)
     {

--- a/src/Spryker/Zed/Discount/Business/QueryString/Specification/CollectorSpecification/CollectorContext.php
+++ b/src/Spryker/Zed/Discount/Business/QueryString/Specification/CollectorSpecification/CollectorContext.php
@@ -9,12 +9,12 @@ namespace Spryker\Zed\Discount\Business\QueryString\Specification\CollectorSpeci
 
 use Generated\Shared\Transfer\ClauseTransfer;
 use Generated\Shared\Transfer\QuoteTransfer;
-use Spryker\Zed\Discount\Dependency\Plugin\CollectorPluginInterface;
+use Spryker\Zed\DiscountExtension\Dependency\Plugin\DiscountableItemCollectorPluginInterface;
 
 class CollectorContext implements CollectorSpecificationInterface
 {
     /**
-     * @var \Spryker\Zed\Discount\Dependency\Plugin\CollectorPluginInterface
+     * @var \Spryker\Zed\DiscountExtension\Dependency\Plugin\DiscountableItemCollectorPluginInterface
      */
     protected $collectorPlugin;
 
@@ -24,10 +24,10 @@ class CollectorContext implements CollectorSpecificationInterface
     protected $clauseTransfer;
 
     /**
-     * @param \Spryker\Zed\Discount\Dependency\Plugin\CollectorPluginInterface $collectorPlugin
+     * @param \Spryker\Zed\DiscountExtension\Dependency\Plugin\DiscountableItemCollectorPluginInterface $collectorPlugin
      * @param \Generated\Shared\Transfer\ClauseTransfer $clauseTransfer
      */
-    public function __construct(CollectorPluginInterface $collectorPlugin, ClauseTransfer $clauseTransfer)
+    public function __construct(DiscountableItemCollectorPluginInterface $collectorPlugin, ClauseTransfer $clauseTransfer)
     {
         $this->collectorPlugin = $collectorPlugin;
         $this->clauseTransfer = $clauseTransfer;

--- a/src/Spryker/Zed/Discount/Business/QueryString/Specification/DecisionRuleProvider.php
+++ b/src/Spryker/Zed/Discount/Business/QueryString/Specification/DecisionRuleProvider.php
@@ -17,12 +17,12 @@ use Spryker\Zed\Discount\DiscountDependencyProvider;
 class DecisionRuleProvider implements SpecificationProviderInterface
 {
     /**
-     * @var \Spryker\Zed\Discount\Dependency\Plugin\DecisionRulePluginInterface[]
+     * @var \Spryker\Zed\DiscountExtension\Dependency\Plugin\DecisionRulePluginInterface[]
      */
     protected $decisionRulePlugins = [];
 
     /**
-     * @param \Spryker\Zed\Discount\Dependency\Plugin\DecisionRulePluginInterface[] $decisionRulePlugins
+     * @param \Spryker\Zed\DiscountExtension\Dependency\Plugin\DecisionRulePluginInterface[] $decisionRulePlugins
      */
     public function __construct(array $decisionRulePlugins)
     {

--- a/src/Spryker/Zed/Discount/Business/QueryString/Specification/DecisionRuleSpecification/DecisionRuleContext.php
+++ b/src/Spryker/Zed/Discount/Business/QueryString/Specification/DecisionRuleSpecification/DecisionRuleContext.php
@@ -10,12 +10,12 @@ namespace Spryker\Zed\Discount\Business\QueryString\Specification\DecisionRuleSp
 use Generated\Shared\Transfer\ClauseTransfer;
 use Generated\Shared\Transfer\ItemTransfer;
 use Generated\Shared\Transfer\QuoteTransfer;
-use Spryker\Zed\Discount\Dependency\Plugin\DecisionRulePluginInterface;
+use Spryker\Zed\DiscountExtension\Dependency\Plugin\DecisionRulePluginInterface;
 
 class DecisionRuleContext implements DecisionRuleSpecificationInterface
 {
      /**
-      * @var \Spryker\Zed\Discount\Dependency\Plugin\DecisionRulePluginInterface
+      * @var \Spryker\Zed\DiscountExtension\Dependency\Plugin\DecisionRulePluginInterface
       */
     protected $rulePlugin;
 
@@ -25,7 +25,7 @@ class DecisionRuleContext implements DecisionRuleSpecificationInterface
     protected $clauseTransfer;
 
      /**
-      * @param \Spryker\Zed\Discount\Dependency\Plugin\DecisionRulePluginInterface $rulePlugin
+      * @param \Spryker\Zed\DiscountExtension\Dependency\Plugin\DecisionRulePluginInterface $rulePlugin
       * @param \Generated\Shared\Transfer\ClauseTransfer $clauseTransfer
       */
     public function __construct(DecisionRulePluginInterface $rulePlugin, ClauseTransfer $clauseTransfer)

--- a/src/Spryker/Zed/Discount/Business/QueryString/Specification/MetaData/MetaDataProvider.php
+++ b/src/Spryker/Zed/Discount/Business/QueryString/Specification/MetaData/MetaDataProvider.php
@@ -11,12 +11,12 @@ use Spryker\Zed\Discount\Business\Exception\QueryStringException;
 use Spryker\Zed\Discount\Business\QueryString\ComparatorOperatorsInterface;
 use Spryker\Zed\Discount\Business\QueryString\LogicalComparators;
 use Spryker\Zed\Discount\Dependency\Plugin\DiscountRuleWithAttributesPluginInterface;
-use Spryker\Zed\Discount\Dependency\Plugin\DiscountRuleWithValueOptionsPluginInterface;
+use Spryker\Zed\DiscountExtension\Dependency\Plugin\DiscountRuleWithValueOptionsPluginInterface;
 
 class MetaDataProvider implements MetaDataProviderInterface
 {
     /**
-     * @var array|\Spryker\Zed\Discount\Dependency\Plugin\DecisionRulePluginInterface[]|\Spryker\Zed\Discount\Dependency\Plugin\CollectorPluginInterface[]
+     * @var array|\Spryker\Zed\DiscountExtension\Dependency\Plugin\DecisionRulePluginInterface[]|\Spryker\Zed\DiscountExtension\Dependency\Plugin\DiscountableItemCollectorPluginInterface[]
      */
     protected $specificationPlugins = [];
 
@@ -43,7 +43,7 @@ class MetaDataProvider implements MetaDataProviderInterface
     protected $availableFieldsMapBuffer = null;
 
     /**
-     * @param \Spryker\Zed\Discount\Dependency\Plugin\DecisionRulePluginInterface[]|\Spryker\Zed\Discount\Dependency\Plugin\CollectorPluginInterface[] $specificationPlugins
+     * @param \Spryker\Zed\DiscountExtension\Dependency\Plugin\DecisionRulePluginInterface[]|\Spryker\Zed\DiscountExtension\Dependency\Plugin\DiscountableItemCollectorPluginInterface[] $specificationPlugins
      * @param \Spryker\Zed\Discount\Business\QueryString\ComparatorOperatorsInterface $comparatorOperators
      * @param \Spryker\Zed\Discount\Business\QueryString\LogicalComparators $logicalComparators
      */
@@ -166,7 +166,7 @@ class MetaDataProvider implements MetaDataProviderInterface
     }
 
     /**
-     * @param \Spryker\Zed\Discount\Dependency\Plugin\DecisionRulePluginInterface|\Spryker\Zed\Discount\Dependency\Plugin\DiscountRuleWithAttributesPluginInterface $specificationPlugin
+     * @param \Spryker\Zed\DiscountExtension\Dependency\Plugin\DecisionRulePluginInterface|\Spryker\Zed\Discount\Dependency\Plugin\DiscountRuleWithAttributesPluginInterface $specificationPlugin
      *
      * @return array
      */

--- a/src/Spryker/Zed/Discount/Dependency/Plugin/CollectorPluginInterface.php
+++ b/src/Spryker/Zed/Discount/Dependency/Plugin/CollectorPluginInterface.php
@@ -7,41 +7,11 @@
 
 namespace Spryker\Zed\Discount\Dependency\Plugin;
 
-use Generated\Shared\Transfer\ClauseTransfer;
-use Generated\Shared\Transfer\QuoteTransfer;
+use Spryker\Zed\DiscountExtension\Dependency\Plugin\DiscountableItemCollectorPluginInterface as ExtensionDiscountableItemCollectorPluginInterface;
 
-interface CollectorPluginInterface
+/**
+ * @deprecated Use {@link \Spryker\Zed\DiscountExtension\Dependency\Plugin\DiscountableItemCollectorPluginInterface} instead.
+ */
+interface CollectorPluginInterface extends ExtensionDiscountableItemCollectorPluginInterface
 {
-    /**
-     * Specification:
-     *  - Collects items to which discount have to be applied, ClauseTransfer holds query string parameters,
-     *  - Uses Spryker\Zed\Discount\Business\QueryString\ComparatorOperatorsInterface to compare item value with ClauseTransfer.
-     *  - Returns array of discountable items with reference to original CalculatedDiscountTransfer, which is modified by reference by distributor.
-     *
-     * @api
-     *
-     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
-     * @param \Generated\Shared\Transfer\ClauseTransfer $clauseTransfer
-     *
-     * @return \Generated\Shared\Transfer\DiscountableItemTransfer[]
-     */
-    public function collect(QuoteTransfer $quoteTransfer, ClauseTransfer $clauseTransfer);
-
-    /**
-     * Name of field as used in query string
-     *
-     * @api
-     *
-     * @return string
-     */
-    public function getFieldName();
-
-    /**
-     * Data types used by this field. (string, integer, list)
-     *
-     * @api
-     *
-     * @return string[]
-     */
-    public function acceptedDataTypes();
 }

--- a/src/Spryker/Zed/Discount/Dependency/Plugin/DecisionRulePluginInterface.php
+++ b/src/Spryker/Zed/Discount/Dependency/Plugin/DecisionRulePluginInterface.php
@@ -7,48 +7,11 @@
 
 namespace Spryker\Zed\Discount\Dependency\Plugin;
 
-use Generated\Shared\Transfer\ClauseTransfer;
-use Generated\Shared\Transfer\ItemTransfer;
-use Generated\Shared\Transfer\QuoteTransfer;
+use Spryker\Zed\DiscountExtension\Dependency\Plugin\DecisionRulePluginInterface as ExtensionDecisionRulePluginInterface;
 
-interface DecisionRulePluginInterface
+/**
+ * @deprecated Use {@link \Spryker\Zed\DiscountExtension\Dependency\Plugin\DecisionRulePluginInterface} instead.
+ */
+interface DecisionRulePluginInterface extends ExtensionDecisionRulePluginInterface
 {
-    /**
-     * Specification:
-     *
-     * - Makes decision on given Quote or Item transfer.
-     * - Uses Spryker\Zed\Discount\Business\QueryString\ComparatorOperatorsInterface to compare item value with ClauseTransfer.
-     * - Returns false when not matching.
-     *
-     * @api
-     *
-     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
-     * @param \Generated\Shared\Transfer\ItemTransfer $itemTransfer
-     * @param \Generated\Shared\Transfer\ClauseTransfer $clauseTransfer
-     *
-     * @return bool
-     */
-    public function isSatisfiedBy(
-        QuoteTransfer $quoteTransfer,
-        ItemTransfer $itemTransfer,
-        ClauseTransfer $clauseTransfer
-    );
-
-    /**
-     * Name of field as used in query string
-     *
-     * @api
-     *
-     * @return string
-     */
-    public function getFieldName();
-
-    /**
-     * Data types used by this field. (string, integer, list)
-     *
-     * @api
-     *
-     * @return array
-     */
-    public function acceptedDataTypes();
 }

--- a/src/Spryker/Zed/Discount/Dependency/Plugin/DiscountRuleWithValueOptionsPluginInterface.php
+++ b/src/Spryker/Zed/Discount/Dependency/Plugin/DiscountRuleWithValueOptionsPluginInterface.php
@@ -7,15 +7,11 @@
 
 namespace Spryker\Zed\Discount\Dependency\Plugin;
 
-interface DiscountRuleWithValueOptionsPluginInterface
+use Spryker\Zed\DiscountExtension\Dependency\Plugin\DiscountRuleWithValueOptionsPluginInterface as ExtensionDiscountRuleWithValueOptionsPluginInterface;
+
+/**
+ * @deprecated Use {@link \Spryker\Zed\DiscountExtension\Dependency\Plugin\DiscountRuleWithValueOptionsPluginInterface} instead.
+ */
+interface DiscountRuleWithValueOptionsPluginInterface extends ExtensionDiscountRuleWithValueOptionsPluginInterface
 {
-    /**
-     * Specification:
-     * - Returns a list of key-value pairs of the available select options.
-     *
-     * @api
-     *
-     * @return array
-     */
-    public function getQueryStringValueOptions();
 }

--- a/src/Spryker/Zed/Discount/DiscountDependencyProvider.php
+++ b/src/Spryker/Zed/Discount/DiscountDependencyProvider.php
@@ -122,7 +122,7 @@ class DiscountDependencyProvider extends AbstractBundleDependencyProvider
     }
 
     /**
-     * @return \Spryker\Zed\Discount\Dependency\Plugin\CollectorPluginInterface[]
+     * @return \Spryker\Zed\DiscountExtension\Dependency\Plugin\DiscountableItemCollectorPluginInterface[]
      */
     protected function getCollectorPlugins()
     {
@@ -134,7 +134,7 @@ class DiscountDependencyProvider extends AbstractBundleDependencyProvider
     }
 
     /**
-     * @return \Spryker\Zed\Discount\Dependency\Plugin\DecisionRulePluginInterface[]
+     * @return \Spryker\Zed\DiscountExtension\Dependency\Plugin\DecisionRulePluginInterface[]
      */
     protected function getDecisionRulePlugins()
     {

--- a/tests/SprykerTest/Zed/Discount/Business/QueryString/Converter/MoneyValueConverterTest.php
+++ b/tests/SprykerTest/Zed/Discount/Business/QueryString/Converter/MoneyValueConverterTest.php
@@ -30,6 +30,20 @@ use Spryker\Zed\Money\Business\MoneyFacade;
 class MoneyValueConverterTest extends Unit
 {
     /**
+     * @uses \Spryker\Zed\Discount\Business\QueryString\Comparator\IsIn::EXPRESSION
+     *
+     * @var string
+     */
+    protected const EXPRESSION_IS_IN = 'is in';
+
+    /**
+     * @uses \Spryker\Zed\Discount\Business\QueryString\Comparator\IsNotIn::EXPRESSION
+     *
+     * @var string
+     */
+    protected const EXPRESSION_IS_NOT_IN = 'is not in';
+
+    /**
      * @return void
      */
     public function testConvertDecimalToCentWhenIsNotInUsedShouldUpdateAllItems()
@@ -39,7 +53,7 @@ class MoneyValueConverterTest extends Unit
         $values = ['10', '12.12', '12,30'];
         $clauseTransfer = new ClauseTransfer();
         $clauseTransfer->setValue(implode(ComparatorOperators::LIST_DELIMITER, $values));
-        $clauseTransfer->setOperator(IsNotIn::EXPRESSION);
+        $clauseTransfer->setOperator(static::EXPRESSION_IS_NOT_IN);
 
         $currencyConverterMock->convertDecimalToCent($clauseTransfer);
 
@@ -60,7 +74,7 @@ class MoneyValueConverterTest extends Unit
         $values = ['10', '12.12', '12,30'];
         $clauseTransfer = new ClauseTransfer();
         $clauseTransfer->setValue(implode(ComparatorOperators::LIST_DELIMITER, $values));
-        $clauseTransfer->setOperator(IsIn::EXPRESSION);
+        $clauseTransfer->setOperator(static::EXPRESSION_IS_IN);
 
         $currencyConverterMock->convertDecimalToCent($clauseTransfer);
 
@@ -80,7 +94,7 @@ class MoneyValueConverterTest extends Unit
 
         $clauseTransfer = new ClauseTransfer();
         $clauseTransfer->setValue('10,50');
-        $clauseTransfer->setOperator(IsIn::EXPRESSION);
+        $clauseTransfer->setOperator(static::EXPRESSION_IS_IN);
 
         $currencyConverterMock->convertDecimalToCent($clauseTransfer);
 


### PR DESCRIPTION
Branch: backport/6.5.0
Ticket: https://spryker.atlassian.net/browse/SUPESC-667
Version: 6.5.0

#### Release Table

   Module                | Release Type         | Constraint Updates         
   :--------------------- | :------------------------ | :---------------------  |
   Discount  | minor                 |                        |

-----------------------------------------

#### Module Discount

##### Change log

Improvements

- Adjusted `ComparatorOperators::compare()` to allow individual comparators to define if comparison with an empty value is allowed.
- Adjusted `IsIn::compare()` to allow checking the intersection of arrays when a list is provided for comparison.
- Adjusted `IsNotIn::compare()` to allow checking the intersection of arrays when a list is provided for comparison and allow comparison with an empty value.
- Impacted `DiscountFacade::queryStringCompare()` by these changes.
- Impacted `DiscountFacade::collectBySku()` by these changes.
- Impacted `DiscountFacade::collectByItemQuantity()` by these changes.
- Impacted `DiscountFacade::collectByItemPrice()` by these changes.
- Impacted `DiscountFacade::isCalendarWeekSatisfiedBy()` by these changes.
- Impacted `DiscountFacade::isCurrencyDecisionRuleSatisfiedBy()` by these changes.
- Impacted `DiscountFacade::isDayOfTheWeekSatisfiedBy()` by these changes.
- Impacted `DiscountFacade::isQuoteGrandTotalSatisfiedBy()` by these changes.
- Impacted `DiscountFacade::isItemPriceSatisfiedBy()` by these changes.
- Impacted `DiscountFacade::isItemQuantitySatisfiedBy()` by these changes.
- Impacted `DiscountFacade::isItemSkuSatisfiedBy()` by these changes.
- Impacted `DiscountFacade::isMonthSatisfiedBy()` by these changes.
- Impacted `DiscountFacade::isPriceModeDecisionRuleSatisfiedBy()` by these changes.
- Impacted `DiscountFacade::isSubTotalSatisfiedBy()` by these changes.
- Impacted `DiscountFacade::isTimeSatisfiedBy()` by these changes.
- Impacted `DiscountFacade::isTotalQuantitySatisfiedBy()` by these changes.
- Impacted `DiscountFacade::calculateDiscounts()` by these changes.
- Impacted `DiscountFacade::validateQueryStringByType()` by these changes.
- Increased `DiscountExtension` dependency version.

Deprecations

- Deprecated `CollectorPluginInterface`.
- Deprecated `DecisionRulePluginInterface`.
- Deprecated `DiscountRuleWithValueOptionsPluginInterface`.
